### PR TITLE
It takes a village

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,6 +56,7 @@ function extract(mbTilesPath, geojson, propName) {
             }
 
             var result = query.bbox(tb.tileToBBOX([x,y,z]))
+            tilesGot = tilesGot + (result.length > 0 ? 0 : result.length - 1);
 
             if (!result) {
                 process.nextTick(tileSaved);
@@ -69,7 +70,6 @@ function extract(mbTilesPath, geojson, propName) {
                         saveTile(extracts[extractName], z, x, y);
 
                     } else {
-
                         writeQueue[extractName] = writeQueue[extractName] || [];
                         writeQueue[extractName].push([z, x, y]);
 

--- a/index.js
+++ b/index.js
@@ -60,24 +60,28 @@ function extract(mbTilesPath, geojson, propName) {
             if (!result) {
                 process.nextTick(tileSaved);
             } else {
-                var extractName = toFileName(result[propName]);
+                if (!Array.isArray(result)) result = [result];
 
-                if (extracts[extractName] && writable[extractName]) {
-                    saveTile(extracts[extractName], z, x, y);
+                for (var result_it = 0; result_it < result.length; result_it++) {
+                    var extractName = toFileName(result[result_it][propName]);
 
-                } else {
+                    if (extracts[extractName] && writable[extractName]) {
+                        saveTile(extracts[extractName], z, x, y);
 
-                    writeQueue[extractName] = writeQueue[extractName] || [];
-                    writeQueue[extractName].push([z, x, y]);
+                    } else {
 
-                    if (!extracts[extractName]) {
-                        writeExtract(extractName, function () {
-                            writable[extractName] = true;
-                            while (writeQueue[extractName].length) {
-                                var t = writeQueue[extractName].pop();
-                                saveTile(extracts[extractName], t[0], t[1], t[2]);
-                            }
-                        });
+                        writeQueue[extractName] = writeQueue[extractName] || [];
+                        writeQueue[extractName].push([z, x, y]);
+
+                        if (!extracts[extractName]) {
+                            writeExtract(extractName, function () {
+                                writable[extractName] = true;
+                                while (writeQueue[extractName].length) {
+                                    var t = writeQueue[extractName].pop();
+                                    saveTile(extracts[extractName], t[0], t[1], t[2]);
+                                }
+                            });
+                        }
                     }
                 }
             }

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ var whichPoly = require('which-polygon');
 var queue = require('queue-async');
 var path = require('path');
 var sm = new (require('sphericalmercator'));
+var tb = require('tilebelt');
 var mkdirp = require('mkdirp');
 
 function extract(mbTilesPath, geojson, propName) {
@@ -54,7 +55,7 @@ function extract(mbTilesPath, geojson, propName) {
                 paused = true;
             }
 
-            var result = query(unproject(z, x + 0.5, y + 0.5));
+            var result = query.bbox(tb.tileToBBOX([x,y,z]))
 
             if (!result) {
                 process.nextTick(tileSaved);
@@ -169,13 +170,6 @@ function writeMBTiles(path, done) {
         done(null, out);
     }
     return out;
-}
-
-function unproject(z, x, y) {
-    var z2 = Math.pow(2, z);
-    var lng = x * 360 / z2 - 180;
-    var lat = 360 / Math.PI * Math.atan(Math.exp((180 - y * 360 / z2) * Math.PI / 180)) - 90;
-    return [lng, lat];
 }
 
 function updateInfo(mbtiles, name, info, callback) {

--- a/index.js
+++ b/index.js
@@ -70,24 +70,24 @@ function extract(mbTilesPath, geojson, propName) {
                         saveQ.defer(saveTile, extracts[extractName], z, x, y);
 
                     } else {
-                        saveQ.defer(function(done) {
-                            writeQueue[extractName] = writeQueue[extractName] || [];
-                            writeQueue[extractName].push([z, x, y]);
+                        saveQ.defer(function(eName, done) {
+                            writeQueue[eName] = writeQueue[eName] || [];
+                            writeQueue[eName].push([z, x, y]);
 
-                            if (!extracts[extractName]) {
-                                writeExtract(extractName, function () {
-                                    writable[extractName] = true;
+                            if (!extracts[eName]) {
+                                writeExtract(eName, function () {
+                                    writable[eName] = true;
                                     var subsaveQ = Q.queue();
-                                    while (writeQueue[extractName].length) {
-                                        var t = writeQueue[extractName].pop();
-                                        subsaveQ.defer(saveTile, extracts[extractName], t[0], t[1], t[2]);
+                                    while (writeQueue[eName].length) {
+                                        var t = writeQueue[eName].pop();
+                                        subsaveQ.defer(saveTile, extracts[eName], t[0], t[1], t[2]);
                                     }
                                     subsaveQ.awaitAll(done);
                                 });
                             } else {
                                 done();
                             }
-                        });
+                        }, extractName);
                     }
                 }
                 

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
   "author": "Vladimir Agafonkin",
   "license": "ISC",
   "dependencies": {
+    "d3-queue": "^3.0.3",
     "mbtiles": "^0.8.2",
     "mkdirp": "^0.5.1",
-    "queue-async": "^1.0.7",
     "sphericalmercator": "^1.0.4",
     "split": "^1.0.0",
     "tilebelt": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "sphericalmercator": "^1.0.4",
     "split": "^1.0.0",
     "tilebelt": "^1.0.1",
-    "which-polygon": "mapbox/which-polygon#bbox"
+    "which-polygon": "2.1.0"
   },
   "devDependencies": {
     "eslint": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "queue-async": "^1.0.7",
     "sphericalmercator": "^1.0.4",
     "split": "^1.0.0",
+    "tilebelt": "^1.0.1",
     "which-polygon": "mapbox/which-polygon#bbox"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "queue-async": "^1.0.7",
     "sphericalmercator": "^1.0.4",
     "split": "^1.0.0",
-    "which-polygon": "^2.0.0"
+    "which-polygon": "mapbox/which-polygon#bbox"
   },
   "devDependencies": {
     "eslint": "^1.9.0",


### PR DESCRIPTION
Tiles shared between countries 2+ countries are currently only given to the country that has a polygon that covers the centre coord of the tile.

For example a tile that covers both SG&MY is given to MY and not SG. This is a deviation of the previous behavior which would divy polygons to both MY & SG if a tile contained both.

This PR improves the current streaming behavior to allow a tile to be shared between multiple parents.

cc/ @aaronlidman @mourner @geohacker 
